### PR TITLE
Add MainClass/MainContent to Layout and bump version

### DIFF
--- a/BlueBlazor/BlueBlazor.csproj
+++ b/BlueBlazor/BlueBlazor.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<PackageId>BlueBlazor</PackageId>
-		<Version>6.3.1</Version>
+		<Version>6.3.1.1</Version>
 
 		<Summary>Component library for Blazor.</Summary>
 		<PackageTags>blue blue-web blazor components bootstrap</PackageTags>

--- a/BlueBlazor/Components/Layout/Layout.razor
+++ b/BlueBlazor/Components/Layout/Layout.razor
@@ -74,9 +74,13 @@
         </dialog>
     </div>
 
-    <main class="blue-layout-main">
-        <div class="@(new CssBuilder("blue-layout-body").AddClass("border-0", NoPageBorder).Build())">
-            @PageContent
-        </div>
+    <main class="@(new CssBuilder("blue-layout-main").AddClass(MainClass).Build())">
+        @if (PageContent != null)
+        {
+            <div class="@(new CssBuilder("blue-layout-body").AddClass("border-0", NoPageBorder).Build())">
+                @PageContent
+            </div>
+        }
+        @MainContent
     </main>
 </div>

--- a/BlueBlazor/Components/Layout/Layout.razor.cs
+++ b/BlueBlazor/Components/Layout/Layout.razor.cs
@@ -20,6 +20,12 @@ public partial class Layout : BlueComponentBase
     public RenderFragment? SideContent { get; set; }
 
     [Parameter]
+    public string? MainClass { get; set; }
+
+    [Parameter]
+    public RenderFragment? MainContent { get; set; }
+
+    [Parameter]
     public RenderFragment? PageContent { get; set; }
 
     [Parameter]

--- a/BlueBlazor/Components/Layout/LayoutBody.razor
+++ b/BlueBlazor/Components/Layout/LayoutBody.razor
@@ -1,0 +1,4 @@
+﻿@namespace BlueBlazor.Components
+@inherits BlueComponentBase
+
+<div class="@ClassValue" style="@Style" @attributes="AdditionalAttributes">@ChildContent</div>

--- a/BlueBlazor/Components/Layout/LayoutBody.razor.cs
+++ b/BlueBlazor/Components/Layout/LayoutBody.razor.cs
@@ -1,0 +1,12 @@
+﻿using BlueBlazor.Shared;
+using Microsoft.AspNetCore.Components;
+
+namespace BlueBlazor.Components;
+
+public partial class LayoutBody : BlueComponentBase
+{
+    private string? ClassValue => new CssBuilder("blue-layout-body").AddClass(Class).Build();
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+}


### PR DESCRIPTION
Expose MainClass (string) and MainContent (RenderFragment) parameters on Layout, apply MainClass to the <main> element, and render PageContent only when present to avoid empty wrappers; MainContent is rendered after PageContent. Also bump package Version to 6.3.1.1.